### PR TITLE
remove unused imports

### DIFF
--- a/voidstranger/Floors/vanilla_floors.py
+++ b/voidstranger/Floors/vanilla_floors.py
@@ -1,5 +1,4 @@
-from typing import Dict, List
-from ..Constants import ItemNames, LocationNames
+from ..Constants import ItemNames
 
 
 # Connection Types: Stairs, Shortcut, Dungeon

--- a/voidstranger/Items.py
+++ b/voidstranger/Items.py
@@ -2,8 +2,6 @@ from typing import Dict, NamedTuple, Optional
 
 from BaseClasses import Item, ItemClassification
 from .Constants import ItemNames
-from .Constants.ItemNames import greed_coin
-from .Locations import VoidStrangerLocationData
 
 void_stranger_base_id: int = 12345000
 

--- a/voidstranger/LocationGroups.py
+++ b/voidstranger/LocationGroups.py
@@ -1,5 +1,4 @@
 from .Constants import LocationNames
-from typing import Dict
 
 vs_location_groups = {
     "Add's Domain Chests": {

--- a/voidstranger/Options.py
+++ b/voidstranger/Options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from Options import Choice, Range, Toggle, OptionGroup, PerGameCommonOptions
+from Options import Choice, Range, Toggle, PerGameCommonOptions
 
 class LogicComplexity(Choice):
     """

--- a/voidstranger/__init__.py
+++ b/voidstranger/__init__.py
@@ -5,15 +5,13 @@ from BaseClasses import Region, Item, MultiWorld, CollectionState, ItemClassific
 from Options import OptionError
 from worlds.AutoWorld import WebWorld, World, LogicMixin
 
-from .Constants.ItemNames import greed_coin
 from .Items import VoidStrangerItem, burden_item_data_table, misc_item_data_table, brand_item_data_table, \
-    statue_item_data_table, shortcut_item_data_table, locust_item_table, item_data_table, item_table, \
-    prog_brand_item_data_table
+    statue_item_data_table, shortcut_item_data_table, item_data_table, item_table
 from .Locations import VoidStrangerLocation, burden_location_data_table, misc_location_data_table,\
     mural_location_data_table, statue_location_data_table, shortcut_location_data_table, chest_location_data_table, \
     location_table, greed_chest_location_data_table
 from .Options import VoidStrangerOptions
-from .Constants import ItemNames, LocationNames
+from .Constants import ItemNames
 from .LocationGroups import vs_location_groups
 
 class VoidStrangerWebWorld(WebWorld):


### PR DESCRIPTION
Quick and dirty passthrough to remove a whole bunch of assorted import calls that aren't actually used anywhere in the code. Makes my IDE much less red-liney, and should (marginally) improve world performance during load time.

Feel free to close this PR with extreme prejudice if you decide you prefer the convenience. I ain't gonna tell you what to do.